### PR TITLE
Fix entry_points for python 3.8 and 3.9

### DIFF
--- a/src/deephaven/plugin/__init__.py
+++ b/src/deephaven/plugin/__init__.py
@@ -41,9 +41,10 @@ def collect_registration_entrypoints():
         from importlib_metadata import entry_points
     elif sys.version_info < (3, 10):
         from importlib.metadata import entry_points as ep
-
         def entry_points(group, name):
-            return [e for e in ep()[group] if e.name == name]
+            # Looks to be a bug in 3.8, 3.9 where entries are doubled up
+            entries = set(ep()[group] or [])
+            return [e for e in entries if e.name == name]
     else:
         from importlib.metadata import entry_points
     return entry_points(


### PR DESCRIPTION
At a minimum, the Red Hat built python 3.8.13 and 3.9.12 are doubling up on entry_points.

Python 3.8.13 (default, Mar 17 2022, 00:00:00)
[GCC 11.2.1 20220127 (Red Hat 11.2.1-9)] on linux

Python 3.9.12 (main, Mar 25 2022, 00:00:00)
[GCC 11.2.1 20220127 (Red Hat 11.2.1-9)] on linux