### PR TITLE
Add JsPlugin

### DIFF
--- a/src/deephaven/plugin/__init__.py
+++ b/src/deephaven/plugin/__init__.py
@@ -1,7 +1,7 @@
 import abc
 from typing import Union, Type
 
-__version__ = "0.3.0.dev2"
+__version__ = "0.3.0.dev3"
 
 DEEPHAVEN_PLUGIN_ENTRY_KEY = "deephaven.plugin"
 DEEPHAVEN_PLUGIN_REGISTRATION_CLASS = "registration_cls"

--- a/src/deephaven/plugin/__init__.py
+++ b/src/deephaven/plugin/__init__.py
@@ -1,10 +1,10 @@
 import abc
 from typing import Union, Type
 
-__version__ = '0.3.0.dev0'
+__version__ = "0.3.0.dev0"
 
-DEEPHAVEN_PLUGIN_ENTRY_KEY = 'deephaven.plugin'
-DEEPHAVEN_PLUGIN_REGISTRATION_CLASS = 'registration_cls'
+DEEPHAVEN_PLUGIN_ENTRY_KEY = "deephaven.plugin"
+DEEPHAVEN_PLUGIN_REGISTRATION_CLASS = "registration_cls"
 
 
 class Plugin(abc.ABC):
@@ -30,6 +30,7 @@ class Registration(abc.ABC):
 
             def register(self, plugin: Union[Plugin, Type[Plugin]]) -> None:
                 self._output.append(plugin)
+
         collector = Collector()
         cls.register_into(collector)
         return collector._output
@@ -37,19 +38,25 @@ class Registration(abc.ABC):
 
 def collect_registration_entrypoints():
     import sys
+
     if sys.version_info < (3, 8):
         from importlib_metadata import entry_points
     elif sys.version_info < (3, 10):
         from importlib.metadata import entry_points as ep
+
         def entry_points(group, name):
             # Looks to be a bug in 3.8, 3.9 where entries are doubled up
             entries = set(ep()[group] or [])
             return [e for e in entries if e.name == name]
+
     else:
         from importlib.metadata import entry_points
-    return entry_points(
-        group=DEEPHAVEN_PLUGIN_ENTRY_KEY,
-        name=DEEPHAVEN_PLUGIN_REGISTRATION_CLASS) or []
+    return (
+        entry_points(
+            group=DEEPHAVEN_PLUGIN_ENTRY_KEY, name=DEEPHAVEN_PLUGIN_REGISTRATION_CLASS
+        )
+        or []
+    )
 
 
 def collect_registration_classes():
@@ -62,18 +69,18 @@ def register_all_into(callback: Registration.Callback):
 
 
 def list_registrations():
-    output = 'Listing Deephaven Plugin registrations:'
+    output = "Listing Deephaven Plugin registrations:"
     for registration_cls in collect_registration_classes():
-        output += f'\n  {registration_cls}'
+        output += f"\n  {registration_cls}"
     print(output)
 
 
 def list_plugins():
-    output = 'Listing Deephaven Plugins:'
+    output = "Listing Deephaven Plugins:"
     for registration_cls in collect_registration_classes():
-        output += f'\n  {registration_cls}'
+        output += f"\n  {registration_cls}"
         plugins = registration_cls.collect_plugins()
-        output += ''.join([f'\n    {plugin}' for plugin in plugins])
+        output += "".join([f"\n    {plugin}" for plugin in plugins])
     print(output)
 
 

--- a/src/deephaven/plugin/__init__.py
+++ b/src/deephaven/plugin/__init__.py
@@ -1,7 +1,7 @@
 import abc
 from typing import Union, Type
 
-__version__ = "0.3.0.dev0"
+__version__ = "0.3.0.dev2"
 
 DEEPHAVEN_PLUGIN_ENTRY_KEY = "deephaven.plugin"
 DEEPHAVEN_PLUGIN_REGISTRATION_CLASS = "registration_cls"

--- a/src/deephaven/plugin/js.py
+++ b/src/deephaven/plugin/js.py
@@ -5,8 +5,8 @@ import typing
 from . import Plugin
 
 
-class JsType(Plugin):
-    """A javascript type plugin. Useful for adding custom javascript code to the server."""
+class JsPlugin(Plugin):
+    """A js plugin. Useful for adding custom code to the server that can be resolved ."""
 
     @abc.abstractmethod
     def distribution_path(self) -> typing.Generator[pathlib.Path, None, None]:

--- a/src/deephaven/plugin/js.py
+++ b/src/deephaven/plugin/js.py
@@ -1,4 +1,5 @@
 import abc
+import json
 import pathlib
 import typing
 
@@ -6,6 +7,31 @@ from . import Plugin
 
 
 class JsType(Plugin):
+    """A javascript type plugin. Useful for adding custom javascript code to the server."""
+
     @abc.abstractmethod
     def path(self) -> typing.Generator[pathlib.Path, None, None]:
+        """A generator that yields the path to package.json."""
         pass
+
+    def package_dict(self) -> dict:
+        """Returns package.json as a dict"""
+        with self.path() as path:
+            with open(path) as file:
+                return json.load(file) 
+
+    @property
+    def name(self) -> str:
+        """Returns the name field from package.json"""
+        return self.package_dict()['name']
+
+    @property
+    def version(self) -> str:
+        """Returns the version field from package.json"""
+        return self.package_dict()['version']
+
+    def __str__(self) -> str:
+        pd = self.package_dict()
+        name = pd['name']
+        version = pd['version']
+        return f"{name}@{version}"

--- a/src/deephaven/plugin/js.py
+++ b/src/deephaven/plugin/js.py
@@ -6,7 +6,7 @@ from . import Plugin
 
 
 class JsPlugin(Plugin):
-    """A js plugin. Useful for adding custom code to the server that can be resolved ."""
+    """A js plugin. Useful for adding custom JS code to the server that can be passed to the web client."""
 
     @abc.abstractmethod
     def distribution_path(self) -> typing.Generator[pathlib.Path, None, None]:

--- a/src/deephaven/plugin/js.py
+++ b/src/deephaven/plugin/js.py
@@ -18,20 +18,20 @@ class JsType(Plugin):
         """Returns package.json as a dict"""
         with self.path() as path:
             with open(path) as file:
-                return json.load(file) 
+                return json.load(file)
 
     @property
     def name(self) -> str:
         """Returns the name field from package.json"""
-        return self.package_dict()['name']
+        return self.package_dict()["name"]
 
     @property
     def version(self) -> str:
         """Returns the version field from package.json"""
-        return self.package_dict()['version']
+        return self.package_dict()["version"]
 
     def __str__(self) -> str:
         pd = self.package_dict()
-        name = pd['name']
-        version = pd['version']
+        name = pd["name"]
+        version = pd["version"]
         return f"{name}@{version}"

--- a/src/deephaven/plugin/js.py
+++ b/src/deephaven/plugin/js.py
@@ -1,0 +1,11 @@
+import abc
+import pathlib
+import typing
+
+from . import Plugin
+
+
+class JsType(Plugin):
+    @abc.abstractmethod
+    def path(self) -> typing.Generator[pathlib.Path, None, None]:
+        pass

--- a/src/deephaven/plugin/js.py
+++ b/src/deephaven/plugin/js.py
@@ -1,5 +1,4 @@
 import abc
-import json
 import pathlib
 import typing
 
@@ -10,28 +9,27 @@ class JsType(Plugin):
     """A javascript type plugin. Useful for adding custom javascript code to the server."""
 
     @abc.abstractmethod
-    def path(self) -> typing.Generator[pathlib.Path, None, None]:
-        """A generator that yields the path to package.json."""
+    def distribution_path(self) -> typing.Generator[pathlib.Path, None, None]:
+        """A generator that yields the distribution path directory."""
         pass
 
-    def package_dict(self) -> dict:
-        """Returns package.json as a dict"""
-        with self.path() as path:
-            with open(path) as file:
-                return json.load(file)
-
     @property
+    @abc.abstractmethod
     def name(self) -> str:
-        """Returns the name field from package.json"""
-        return self.package_dict()["name"]
+        """The plugin name"""
+        pass
 
     @property
+    @abc.abstractmethod
     def version(self) -> str:
-        """Returns the version field from package.json"""
-        return self.package_dict()["version"]
+        """The plugin version"""
+        pass
+
+    @property
+    @abc.abstractmethod
+    def main(self) -> str:
+        """The main js file, the relative path with respect to distribution_path."""
+        pass
 
     def __str__(self) -> str:
-        pd = self.package_dict()
-        name = pd["name"]
-        version = pd["version"]
-        return f"{name}@{version}"
+        return f"{self.name}@{self.version}"

--- a/src/deephaven/plugin/object.py
+++ b/src/deephaven/plugin/object.py
@@ -5,40 +5,53 @@ from . import Plugin, Registration, register_all_into
 
 
 class Reference:
+    """A reference."""
     def __init__(self, index: int, type: Optional[str]):
         self._index = index
         self._type = type
 
     @property
     def index(self) -> int:
+        """The index, which is defined by the order in which references are created.
+        May be used in the output stream to refer to the reference from the client."""
         return self._index
 
     @property
     def type(self) -> Optional[str]:
+        """The type."""
         return self._type
 
 
 class Exporter(abc.ABC):
+    """The interface for creating new references during ObjectType.to_bytes."""
     @abc.abstractmethod
     def reference(self,
                   object,
                   allow_unknown_type: bool = False,
                   force_new: bool = False) -> Optional[Reference]:
+        """Gets the reference for object if it has already been created and force_new is False,
+        otherwise creates a new one. If allow_unknown_type is False, and no type can be found, no
+        reference will be created."""
         pass
 
 
 class ObjectType(Plugin):
+    """An object type plugin. Useful for serializing custom objects between the server / client."""
+    
     @property
     @abc.abstractmethod
     def name(self) -> str:
+        """The name of the object type."""
         pass
 
     @abc.abstractmethod
     def is_type(self, object) -> bool:
+        """Returns true if, and only if, the object is compatible with this object type."""
         pass
 
     @abc.abstractmethod
     def to_bytes(self, exporter: Exporter, object) -> bytes:
+        """Serializes object into bytes. Must only be called with a compatible object."""
         pass
 
 

--- a/src/deephaven/plugin/object.py
+++ b/src/deephaven/plugin/object.py
@@ -1,7 +1,7 @@
 import abc
 from typing import Optional, Union, Type
 
-from .. import Plugin, Registration, register_all_into
+from . import Plugin, Registration, register_all_into
 
 
 class Reference:

--- a/src/deephaven/plugin/object.py
+++ b/src/deephaven/plugin/object.py
@@ -6,6 +6,7 @@ from . import Plugin, Registration, register_all_into
 
 class Reference:
     """A reference."""
+
     def __init__(self, index: int, type: Optional[str]):
         self._index = index
         self._type = type
@@ -24,11 +25,11 @@ class Reference:
 
 class Exporter(abc.ABC):
     """The interface for creating new references during ObjectType.to_bytes."""
+
     @abc.abstractmethod
-    def reference(self,
-                  object,
-                  allow_unknown_type: bool = False,
-                  force_new: bool = False) -> Optional[Reference]:
+    def reference(
+        self, object, allow_unknown_type: bool = False, force_new: bool = False
+    ) -> Optional[Reference]:
         """Gets the reference for object if it has already been created and force_new is False,
         otherwise creates a new one. If allow_unknown_type is False, and no type can be found, no
         reference will be created."""
@@ -37,7 +38,7 @@ class Exporter(abc.ABC):
 
 class ObjectType(Plugin):
     """An object type plugin. Useful for serializing custom objects between the server / client."""
-    
+
     @property
     @abc.abstractmethod
     def name(self) -> str:
@@ -74,6 +75,7 @@ def find_object_type(object) -> Optional[ObjectType]:
         @property
         def found(self) -> Optional[ObjectType]:
             return self._found
+
     visitor = Visitor()
     register_all_into(visitor)
     return visitor.found


### PR DESCRIPTION
Tested in combination with https://github.com/deephaven/deephaven-core/pull/2908; published .dev versions to PyPi for downstream consumption.

Adds the python class `deephaven.plugin.js.JsPlugin`. This allows for the development of JS plugins which can be provided by python packages. See https://github.com/deephaven/js-plugin-template for JS expectations and requirements.